### PR TITLE
Remove § formatting codes from messages

### DIFF
--- a/Common/src/main/java/me/hypherionmc/sdlink/server/ServerEvents.java
+++ b/Common/src/main/java/me/hypherionmc/sdlink/server/ServerEvents.java
@@ -136,6 +136,7 @@ public class ServerEvents implements IMinecraftHelper {
 
                 msg = msg.replaceAll("<" + username + ">", "");
                 msg = msg.replace(username, "");
+                username = username.replaceAll("§[\\w]", "");
 
                 botEngine.sendToDiscord(
                         modConfig.messageConfig.chat.replace("%player%", username).replace("%message%", msg.replace("@everyone", "").replace("@Everyone", "").replace("@here", "").replace("@Here", "")),
@@ -173,7 +174,7 @@ public class ServerEvents implements IMinecraftHelper {
         if (botEngine != null && modConfig.generalConfig.enabled) {
             if (modConfig.chatConfig.joinAndLeaveMessages) {
                 botEngine.sendToDiscord(
-                        modConfig.messageConfig.playerJoined.replace("%player%", player.getDisplayName().getString()),
+                        modConfig.messageConfig.playerJoined.replace("%player%", player.getDisplayName().getString().replaceAll("§[\\w]", "")),
                         "server",
                         "",
                         modConfig.messageDestinations.joinLeaveInChat
@@ -186,7 +187,7 @@ public class ServerEvents implements IMinecraftHelper {
         if (botEngine != null && modConfig.generalConfig.enabled) {
             if (modConfig.chatConfig.joinAndLeaveMessages) {
                 botEngine.sendToDiscord(
-                        modConfig.messageConfig.playerLeft.replace("%player%", player.getDisplayName().getString()),
+                        modConfig.messageConfig.playerLeft.replace("%player%", player.getDisplayName().getString().replaceAll("§[\\w]", "")),
                         "server",
                         "",
                         modConfig.messageDestinations.joinLeaveInChat
@@ -199,7 +200,7 @@ public class ServerEvents implements IMinecraftHelper {
         if (botEngine != null && modConfig.generalConfig.enabled) {
             if (modConfig.chatConfig.deathMessages) {
                 String msg = modConfig.messageConfig.formatting ? DiscordSerializer.INSTANCE.serialize(message.copy()) : ChatFormatting.stripFormatting(message.getString());
-
+                msg = msg.replaceAll("§[\\w]", "");
                 botEngine.sendToDiscord(
                         msg,
                         "server",
@@ -213,6 +214,7 @@ public class ServerEvents implements IMinecraftHelper {
     public void onPlayerAdvancement(Component name, Component advancement, Component advancement_description) {
         if (botEngine != null && modConfig.chatConfig.advancementMessages) {
             String username = modConfig.messageConfig.formatting ? DiscordSerializer.INSTANCE.serialize(name.copy()) : ChatFormatting.stripFormatting(name.getString());
+            username = username.replaceAll("§[\\w]", "");
             String advancemnt = modConfig.messageConfig.formatting ? DiscordSerializer.INSTANCE.serialize(advancement.copy()) : ChatFormatting.stripFormatting(advancement.getString());
             String advancementBody = modConfig.messageConfig.formatting ? DiscordSerializer.INSTANCE.serialize(advancement_description.copy()) : ChatFormatting.stripFormatting(advancement_description.getString());
 


### PR DESCRIPTION
In order to display "roles" in a semi-vanilla server, I use the vanilla "teams" to create the roles and then edit the scoreboard.dat so I can add formatting to the prefix of said roles. This results in the discord chat looking quite bad so I made this change to circumvent that.

Before
![image](https://user-images.githubusercontent.com/20412235/212905678-42ec59b3-add5-4a45-8cf7-7cb9f0d6e0f4.png)

After
![image](https://user-images.githubusercontent.com/20412235/212905755-3dc79efd-9a2a-4b83-8870-6cc921fdcb4e.png)
