### PR TITLE
Fix for Slash Commands in fr_fr lang

### DIFF
--- a/Common/src/main/resources/assets/sdlink/lang/fr_fr.json
+++ b/Common/src/main/resources/assets/sdlink/lang/fr_fr.json
@@ -55,7 +55,7 @@
   "command.setchannel.failed": "Échec de l'enregistrement de la configuration : %s",
 
   "command.staffunverify.help": "Retire la vérification du compte Minecraft d’un autre joueur",
-  "command.staffverify.help": "Permet aux membres du staff de vérifier les comptes Minecraft sans passer par la vérification classique",
+  "command.staffverify.help": "Permet aux membres du staff de vérifier les comptes Minecraft",
 
   "command.unverify.help": "Retire la vérification de votre compte Minecraft précédemment vérifié",
   "command.unverify.failed": "Désolé, nous n'avons pas pu dé-vérifier votre compte Minecraft. Veuillez réessayer",


### PR DESCRIPTION
Update staff verify command help text in French
because the "help" section must have between 1 and 100 character for work.
this fix remove some text in the "fr_fr.json" config but keep a frenchy french lol