### PR TITLE
Support custom avatar URLs with username and add embed color support

### DIFF
--- a/Common/src/main/java/com/hypherionmc/sdlink/api/accounts/DiscordAuthor.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/api/accounts/DiscordAuthor.java
@@ -71,7 +71,7 @@ public final class DiscordAuthor {
     public static DiscordAuthor of(String displayName, String uuid, String username) {
         return new DiscordAuthor(
                 displayName,
-                SDLinkConfig.INSTANCE.chatConfig.playerAvatarType.resolve(SDLinkPlatform.minecraftHelper.isOnlineMode() ? uuid : username),
+                SDLinkConfig.INSTANCE.chatConfig.playerAvatarType.resolve(SDLinkPlatform.minecraftHelper.isOnlineMode() ? uuid : username, username),
                 username,
                 false,
                 uuid
@@ -99,7 +99,7 @@ public final class DiscordAuthor {
     }
 
     public DiscordAuthor setPlayerAvatar(String usr, String userid) {
-        realPlayerAvatar = SDLinkConfig.INSTANCE.chatConfig.playerAvatarType.resolve(SDLinkPlatform.minecraftHelper.isOnlineMode() ? userid : usr);
+        realPlayerAvatar = SDLinkConfig.INSTANCE.chatConfig.playerAvatarType.resolve(SDLinkPlatform.minecraftHelper.isOnlineMode() ? userid : usr, usr);
         return this;
     }
 

--- a/Common/src/main/java/com/hypherionmc/sdlink/api/messaging/discord/DiscordMessage.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/api/messaging/discord/DiscordMessage.java
@@ -48,6 +48,7 @@ public final class DiscordMessage {
     private final MessageType messageType;
     private final DiscordAuthor author;
     private final String message;
+    private final String embedColor;
     private final Runnable afterSend;
 
     /**
@@ -57,6 +58,7 @@ public final class DiscordMessage {
         this.messageType = builder.getMessageType();
         this.author = builder.getAuthor();
         this.message = builder.getMessage();
+        this.embedColor = builder.getEmbedColor();
         this.afterSend = builder.getAfterSend();
     }
 
@@ -277,6 +279,9 @@ public final class DiscordMessage {
             }
 
             builder.setDescription(message);
+            if (!getOrElse(embedColor, "").isEmpty()) {
+                setEmbedColor(builder, embedColor);
+            }
             return builder;
         }
 
@@ -322,11 +327,7 @@ public final class DiscordMessage {
             builder.setTimestamp(OffsetDateTime.parse(String.valueOf(data.timestamp)));
         }
 
-        if (getOrElse(data.color, "#000000").startsWith("#")) {
-            builder.setColor(Color.decode(getOrElse(data.color, "#000000")));
-        } else {
-            builder.setColor(Integer.parseInt(getOrElse(data.color, "#000000"), 16));
-        }
+        setEmbedColor(builder, getOrElse(embedColor, data.color));
 
         if (data.thumbnail != null) {
             builder.setThumbnail(getOrElse(data.thumbnail.url, null));
@@ -358,5 +359,18 @@ public final class DiscordMessage {
         }
 
         return builder;
+    }
+
+    private void setEmbedColor(EmbedBuilder builder, String color) {
+        String configuredColor = getOrElse(color, "#000000").trim();
+        if (configuredColor.isEmpty()) {
+            configuredColor = "#000000";
+        }
+
+        if (configuredColor.startsWith("#")) {
+            builder.setColor(Color.decode(configuredColor));
+        } else {
+            builder.setColor(Integer.parseInt(configuredColor, 16));
+        }
     }
 }

--- a/Common/src/main/java/com/hypherionmc/sdlink/api/messaging/discord/DiscordMessageBuilder.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/api/messaging/discord/DiscordMessageBuilder.java
@@ -26,6 +26,7 @@ public final class DiscordMessageBuilder {
     private final MessageType messageType;
     private DiscordAuthor author;
     private String message;
+    private String embedColor;
     private Runnable afterSend;
 
     /**
@@ -90,6 +91,14 @@ public final class DiscordMessageBuilder {
 
     public DiscordMessageBuilder afterSend(Runnable afterSend) {
         this.afterSend = afterSend;
+        return this;
+    }
+
+    /**
+     * Override the configured embed color for this message. Empty values keep the embed JSON color.
+     */
+    public DiscordMessageBuilder embedColor(String embedColor) {
+        this.embedColor = embedColor;
         return this;
     }
 

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/config/AvatarType.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/config/AvatarType.java
@@ -26,9 +26,11 @@ public enum AvatarType {
         return this.url;
     }
 
-    public String resolve(String uuid) {
+    public String resolve(String uuid, String username) {
         if (this == CUSTOM) {
-            return SDLinkConfig.INSTANCE.chatConfig.customAvatarService.replace("{uuid}", uuid);
+            return SDLinkConfig.INSTANCE.chatConfig.customAvatarService
+                    .replace("{uuid}", uuid)
+                    .replace("{username}", username);
         }
 
         return this.url.replace("{uuid}", uuid);

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/config/SDLinkConfig.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/config/SDLinkConfig.java
@@ -37,7 +37,7 @@ public final class SDLinkConfig extends AbstractConfig<SDLinkConfig> {
     // DO NOT REMOVE TRANSIENT HERE... OTHERWISE, THE STUPID CONFIG LIBRARY
     // WILL TRY TO WRITE THESE TO THE CONFIG
     public transient static SDLinkConfig INSTANCE;
-    public transient static int configVer = 37;
+    public transient static int configVer = 38;
     public transient static boolean hasConfigLoaded = false;
     public transient static boolean wasReload = false;
 

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/config/impl/ChatSettingsConfig.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/config/impl/ChatSettingsConfig.java
@@ -43,7 +43,7 @@ public final class ChatSettingsConfig {
     public boolean hideIpsInConsoleRelay = true;
 
     @Path("customAvatarService")
-    @SpecComment("Add your own Avatar service URL here. Use {uuid} to replace the player ID in the URL")
+    @SpecComment("Add your own Avatar service URL here. Use {uuid} to replace the player ID and {username} to replace the player name in the URL")
     public String customAvatarService = "https://crafatar.com/avatars/{uuid}";
 
     @Path("playerAvatarType")

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/config/impl/MessageFormatting.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/config/impl/MessageFormatting.java
@@ -26,47 +26,95 @@ public final class MessageFormatting {
     @SpecComment("Server Starting Message")
     public String serverStarting = "*Server is starting...*";
 
+    @Path("serverStartingColor")
+    @SpecComment("Optional embed color for the Server Starting Message. Leave empty to use the embed JSON color")
+    public String serverStartingColor = "";
+
     @Path("serverStarted")
     @SpecComment("Server Started Message")
     public String serverStarted = "*Server has started. Enjoy!*";
+
+    @Path("serverStartedColor")
+    @SpecComment("Optional embed color for the Server Started Message. Leave empty to use the embed JSON color")
+    public String serverStartedColor = "";
 
     @Path("serverStopping")
     @SpecComment("Server Stopping Message")
     public String serverStopping = "*Server is stopping...*";
 
+    @Path("serverStoppingColor")
+    @SpecComment("Optional embed color for the Server Stopping Message. Leave empty to use the embed JSON color")
+    public String serverStoppingColor = "";
+
     @Path("serverStopped")
     @SpecComment("Server Stopped Message")
     public String serverStopped = "*Server has stopped...*";
+
+    @Path("serverStoppedColor")
+    @SpecComment("Optional embed color for the Server Stopped Message. Leave empty to use the embed JSON color")
+    public String serverStoppedColor = "";
 
     @Path("playerJoined")
     @SpecComment("Player Joined Message. Use %player% to display the player name")
     public String playerJoined = "*%player% has joined the server!*";
 
+    @Path("playerJoinedColor")
+    @SpecComment("Optional embed color for Player Joined Messages. Leave empty to use the embed JSON color")
+    public String playerJoinedColor = "";
+
     @Path("playerLeft")
     @SpecComment("Player Left Message. Use %player% to display the player name")
     public String playerLeft = "*%player% has left the server!*";
+
+    @Path("playerLeftColor")
+    @SpecComment("Optional embed color for Player Left Messages. Leave empty to use the embed JSON color")
+    public String playerLeftColor = "";
 
     @Path("advancements")
     @SpecComment("Advancement Messages. Available variables: %player%, %title%, %description%")
     public String achievements = "*%player% has made the advancement [%title%]: %description%*";
 
+    @Path("advancementsColor")
+    @SpecComment("Optional embed color for Advancement Messages. Leave empty to use the embed JSON color")
+    public String achievementsColor = "";
+
     @Path("chat")
     @SpecComment("Chat Messages. THIS DOES NOT APPLY TO EMBED OR WEBHOOK MESSAGES. Available variables: %player%, %message%, %mcname%")
     public String chat = "%player%: %message%";
+
+    @Path("chatColor")
+    @SpecComment("Optional embed color for Chat Messages. Leave empty to use the embed JSON color")
+    public String chatColor = "";
 
     @Path("death")
     @SpecComment("Death Messages. Available variables: %player%, %message%")
     public String death = "%player% %message%";
 
+    @Path("deathColor")
+    @SpecComment("Optional embed color for Death Messages. Leave empty to use the embed JSON color")
+    public String deathColor = "";
+
     @Path("whitelistAdded")
     @SpecComment("Message to be sent when a player is added to the whitelist")
     public String whitelistAdded = "%player% has been whitelisted!";
+
+    @Path("whitelistAddedColor")
+    @SpecComment("Optional embed color for Whitelist Added Messages. Leave empty to use the embed JSON color")
+    public String whitelistAddedColor = "";
 
     @Path("whitelistRemoved")
     @SpecComment("Message to be sent when a player is removed from the whitelist")
     public String whitelistRemoved = "%player% has been removed from the whitelist!";
 
+    @Path("whitelistRemovedColor")
+    @SpecComment("Optional embed color for Whitelist Removed Messages. Leave empty to use the embed JSON color")
+    public String whitelistRemovedColor = "";
+
     @Path("commands")
     @SpecComment("Command Messages. Available variables: %player%, %command%")
     public String commands = "%player% **executed command**: *%command%*";
+
+    @Path("commandsColor")
+    @SpecComment("Optional embed color for Command Messages. Leave empty to use the embed JSON color")
+    public String commandsColor = "";
 }

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/relay/SDLinkRelayClient.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/relay/SDLinkRelayClient.java
@@ -278,6 +278,7 @@ public final class SDLinkRelayClient extends WebSocketAdapter {
 
                     DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.CHAT)
                             .message(msg)
+                            .embedColor(SDLinkConfig.INSTANCE.messageFormatting.chatColor)
                             .author(!dataMessage.isFromServer() ? author : DiscordAuthor.getServer())
                             .build();
 
@@ -296,6 +297,7 @@ public final class SDLinkRelayClient extends WebSocketAdapter {
 
                     DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.JOIN)
                             .message(msg)
+                            .embedColor(SDLinkConfig.INSTANCE.messageFormatting.playerJoinedColor)
                             .author(DiscordAuthor.getServer()
                                     .setPlayerName(dataMessage.displayName().asString())
                                     .setPlayerAvatar(dataMessage.getUsername(), dataMessage.getUuid().toString()))
@@ -315,6 +317,7 @@ public final class SDLinkRelayClient extends WebSocketAdapter {
 
                     DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.LEAVE)
                             .message(msg)
+                            .embedColor(SDLinkConfig.INSTANCE.messageFormatting.playerLeftColor)
                             .author(DiscordAuthor.getServer()
                                     .setPlayerName(dataMessage.displayName().asString())
                                     .setPlayerAvatar(dataMessage.getUsername(), dataMessage.getUuid().toString()))
@@ -343,6 +346,7 @@ public final class SDLinkRelayClient extends WebSocketAdapter {
 
                     DiscordMessage message = new DiscordMessageBuilder(MessageType.DEATH)
                             .message(finalMessage)
+                            .embedColor(SDLinkConfig.INSTANCE.messageFormatting.deathColor)
                             .author(DiscordAuthor.getServer()
                                     .setPlayerName(dataMessage.displayName().asString())
                                     .setPlayerAvatar(dataMessage.getUsername(), dataMessage.getUuid().toString()))
@@ -363,6 +367,7 @@ public final class SDLinkRelayClient extends WebSocketAdapter {
 
                     DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.ADVANCEMENTS)
                             .message(msg)
+                            .embedColor(SDLinkConfig.INSTANCE.messageFormatting.achievementsColor)
                             .author(DiscordAuthor.getServer()
                                     .setPlayerName(dataMessage.displayName().asString())
                                     .setPlayerAvatar(dataMessage.getUsername(), dataMessage.getUuid().toString()))

--- a/Common/src/main/java/com/hypherionmc/sdlink/server/ServerEvents.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/server/ServerEvents.java
@@ -96,6 +96,7 @@ public final class ServerEvents {
         if (canSendMessage() && SDLinkConfig.INSTANCE.chatConfig.serverStarting) {
             DiscordMessage message = new DiscordMessageBuilder(MessageType.START)
                     .message(SDLinkConfig.INSTANCE.messageFormatting.serverStarting)
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.serverStartingColor)
                     .author(DiscordAuthor.getServer())
                     .build();
 
@@ -109,6 +110,7 @@ public final class ServerEvents {
         if (canSendMessage() && SDLinkConfig.INSTANCE.chatConfig.serverStarted) {
             DiscordMessage message = new DiscordMessageBuilder(MessageType.START)
                     .message(SDLinkConfig.INSTANCE.messageFormatting.serverStarted)
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.serverStartedColor)
                     .author(DiscordAuthor.getServer())
                     .build();
 
@@ -132,6 +134,7 @@ public final class ServerEvents {
         if (canSendMessage() && SDLinkConfig.INSTANCE.chatConfig.serverStopping) {
             DiscordMessage message = new DiscordMessageBuilder(MessageType.STOP)
                     .message(SDLinkConfig.INSTANCE.messageFormatting.serverStopping)
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.serverStoppingColor)
                     .author(DiscordAuthor.getServer())
                     .afterSend(() -> {
                         // Stop Log Relay
@@ -154,6 +157,7 @@ public final class ServerEvents {
         if (canSendMessage() && SDLinkConfig.INSTANCE.chatConfig.serverStopped) {
             DiscordMessage message = new DiscordMessageBuilder(MessageType.STOP)
                     .message(SDLinkConfig.INSTANCE.messageFormatting.serverStopped)
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.serverStoppedColor)
                     .author(DiscordAuthor.getServer())
                     .afterSend(() -> BotController.INSTANCE.shutdownBot(false))
                     .build();
@@ -221,6 +225,7 @@ public final class ServerEvents {
 
                 DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.CHAT)
                         .message(msg)
+                        .embedColor(SDLinkConfig.INSTANCE.messageFormatting.chatColor)
                         .author(!fromServer ? author : DiscordAuthor.getServer())
                         .build();
 
@@ -304,6 +309,7 @@ public final class ServerEvents {
             DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.CHAT)
                     .author(author)
                     .message(msg)
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.chatColor)
                     .build();
 
             discordMessage.sendMessage();
@@ -335,6 +341,7 @@ public final class ServerEvents {
             DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.CHAT)
                     .author(author)
                     .message(event.getMessage().asString(SDLinkConfig.INSTANCE.chatConfig.formatting))
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.chatColor)
                     .build();
 
             discordMessage.sendMessage();
@@ -348,6 +355,7 @@ public final class ServerEvents {
             DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.CHAT)
                     .author(author)
                     .message(msg)
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.chatColor)
                     .build();
 
             discordMessage.sendMessage();
@@ -395,6 +403,7 @@ public final class ServerEvents {
                                 .replace("%player%", username)
                                 .replace("%command%", command)
                 )
+                .embedColor(SDLinkConfig.INSTANCE.messageFormatting.commandsColor)
                 .build();
 
         discordMessage.sendMessage(sendImmediately);
@@ -440,6 +449,7 @@ public final class ServerEvents {
 
         DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.JOIN)
                 .message(msg)
+                .embedColor(SDLinkConfig.INSTANCE.messageFormatting.playerJoinedColor)
                 .author(DiscordAuthor.getServer()
                         .setPlayerName(event.getPlayer().getName().asString()).setGameProfile(event.getPlayer().getGameProfile())
                         .setPlayerAvatar(event.getPlayer().getGameProfile().getName(), event.getPlayer().getStringUUID()))
@@ -499,6 +509,7 @@ public final class ServerEvents {
 
         DiscordMessage message = new DiscordMessageBuilder(MessageType.LEAVE)
                 .message(msg)
+                .embedColor(SDLinkConfig.INSTANCE.messageFormatting.playerLeftColor)
                 .author(DiscordAuthor.getServer()
                         .setPlayerName(event.getPlayer().getName().asString()).setGameProfile(event.getPlayer().getGameProfile())
                         .setPlayerAvatar(event.getPlayer().getGameProfile().getName(), SDLinkMCPlatform.INSTANCE.getPlayerSkinUUID(event.getPlayer())))
@@ -567,6 +578,7 @@ public final class ServerEvents {
 
             DiscordMessage message = new DiscordMessageBuilder(MessageType.DEATH)
                     .message(finalMessage)
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.deathColor)
                     .author(DiscordAuthor.getServer()
                             .setGameProfile(event.getPlayer().getGameProfile())
                             .setPlayerName(player.getDisplayName().asString())
@@ -617,6 +629,7 @@ public final class ServerEvents {
 
                 DiscordMessage discordMessage = new DiscordMessageBuilder(MessageType.ADVANCEMENTS)
                         .message(msg)
+                        .embedColor(SDLinkConfig.INSTANCE.messageFormatting.achievementsColor)
                         .author(DiscordAuthor.getServer()
                                 .setGameProfile(event.getPlayer().getGameProfile())
                                 .setPlayerName(event.getPlayer().getDisplayName().asString())
@@ -687,7 +700,11 @@ public final class ServerEvents {
         Debugger.INSTANCE.log("Relaying message from {}", thread);
 
         try {
-            DiscordMessage message = new DiscordMessageBuilder(MessageType.CHAT).author(DiscordAuthor.getServer()).message(event.getComponent().asString(SDLinkConfig.INSTANCE.chatConfig.formatting)).build();
+            DiscordMessage message = new DiscordMessageBuilder(MessageType.CHAT)
+                    .author(DiscordAuthor.getServer())
+                    .message(event.getComponent().asString(SDLinkConfig.INSTANCE.chatConfig.formatting))
+                    .embedColor(SDLinkConfig.INSTANCE.messageFormatting.chatColor)
+                    .build();
             message.sendMessage();
         } catch (Exception e) {
             Debugger.INSTANCE.log("Failed to broadcast message", e);
@@ -748,6 +765,7 @@ public final class ServerEvents {
 
         DiscordMessage message = new DiscordMessageBuilder(MessageType.DEATH)
                 .message(finalMessage.replace("%player%", name))
+                .embedColor(SDLinkConfig.INSTANCE.messageFormatting.deathColor)
                 .author(DiscordAuthor.getServer()
                         .setGameProfile(event.getPlayer().getGameProfile())
                         .setPlayerName(player.getDisplayName().asString())
@@ -764,6 +782,7 @@ public final class ServerEvents {
 
         DiscordMessage message = new DiscordMessageBuilder(MessageType.WHITELIST)
                 .message(SDLinkConfig.INSTANCE.messageFormatting.whitelistAdded.replace("%player%", event.getProfile().getName()))
+                .embedColor(SDLinkConfig.INSTANCE.messageFormatting.whitelistAddedColor)
                 .author(DiscordAuthor.getServer().setGameProfile(event.getProfile()))
                 .build();
 
@@ -777,6 +796,7 @@ public final class ServerEvents {
 
         DiscordMessage message = new DiscordMessageBuilder(MessageType.WHITELIST)
                 .message(SDLinkConfig.INSTANCE.messageFormatting.whitelistRemoved.replace("%player%", event.getProfile().getName()))
+                .embedColor(SDLinkConfig.INSTANCE.messageFormatting.whitelistRemovedColor)
                 .author(DiscordAuthor.getServer().setGameProfile(event.getProfile()))
                 .build();
 


### PR DESCRIPTION
This pull request adds support for customizable embed colors for various Discord messages sent by the application, allowing users to specify colors for different message types via configuration. It also enhances avatar URL customization by supporting both player UUID and username placeholders. These changes improve the flexibility and appearance of Discord integrations.

**Embed color customization:**

* Added an `embedColor` field to `DiscordMessage` and `DiscordMessageBuilder`, along with a builder method to set it. This allows specifying a custom color for each message. [[1]](diffhunk://#diff-c1d41f2ce24222f3f5b93c14e57814bfbeaa9c76d658a5b2e5a0581fb21d156fR51) [[2]](diffhunk://#diff-c1d41f2ce24222f3f5b93c14e57814bfbeaa9c76d658a5b2e5a0581fb21d156fR61) [[3]](diffhunk://#diff-74248936ac2ae70a3edd7d7963bbf72d13cb5a70a6a0a10d3999990491ae31a3R29) [[4]](diffhunk://#diff-74248936ac2ae70a3edd7d7963bbf72d13cb5a70a6a0a10d3999990491ae31a3R97-R104)
* Updated the embed construction logic to use the specified embed color if provided, with a helper method to handle color parsing. [[1]](diffhunk://#diff-c1d41f2ce24222f3f5b93c14e57814bfbeaa9c76d658a5b2e5a0581fb21d156fR282-R284) [[2]](diffhunk://#diff-c1d41f2ce24222f3f5b93c14e57814bfbeaa9c76d658a5b2e5a0581fb21d156fL325-R330) [[3]](diffhunk://#diff-c1d41f2ce24222f3f5b93c14e57814bfbeaa9c76d658a5b2e5a0581fb21d156fR363-R375)
* Modified message sending in `SDLinkRelayClient` and `ServerEvents` to set the embed color for chat, join, leave, death, advancement, server lifecycle, and command messages using the new configuration options. [[1]](diffhunk://#diff-e33bf01a0fcdfa2bd0e190d16a121e91dd13d76cdf705df0a5e664ed735798b8R281) [[2]](diffhunk://#diff-e33bf01a0fcdfa2bd0e190d16a121e91dd13d76cdf705df0a5e664ed735798b8R300) [[3]](diffhunk://#diff-e33bf01a0fcdfa2bd0e190d16a121e91dd13d76cdf705df0a5e664ed735798b8R320) [[4]](diffhunk://#diff-e33bf01a0fcdfa2bd0e190d16a121e91dd13d76cdf705df0a5e664ed735798b8R349) [[5]](diffhunk://#diff-e33bf01a0fcdfa2bd0e190d16a121e91dd13d76cdf705df0a5e664ed735798b8R370) [[6]](diffhunk://#diff-71db24581706d76623996e466df2fdd25dae49abe40da96414ec917e90f5c203R99) [[7]](diffhunk://#diff-71db24581706d76623996e466df2fdd25dae49abe40da96414ec917e90f5c203R113) [[8]](diffhunk://#diff-71db24581706d76623996e466df2fdd25dae49abe40da96414ec917e90f5c203R137) [[9]](diffhunk://#diff-71db24581706d76623996e466df2fdd25dae49abe40da96414ec917e90f5c203R160) [[10]](diffhunk://#diff-71db24581706d76623996e466df2fdd25dae49abe40da96414ec917e90f5c203R228) [[11]](diffhunk://#diff-71db24581706d76623996e466df2fdd25dae49abe40da96414ec917e90f5c203R312) [[12]](diffhunk://#diff-71db24581706d76623996e466df2fdd25dae49abe40da96414ec917e90f5c203R344)
* Extended `MessageFormatting` config to include new color fields (e.g., `serverStartingColor`, `chatColor`, etc.) for each message type, with documentation.

**Avatar URL customization:**

* Updated the `customAvatarService` config and `AvatarType.resolve` method to support `{username}` as a placeholder in addition to `{uuid}` for avatar URLs, improving avatar customization for both online and offline modes. [[1]](diffhunk://#diff-72aa99390037dc3fbd5c8f91f75e5eced0802269242f039bb75f554873a0470eL29-R33) [[2]](diffhunk://#diff-79aa6a7f68717fb3efc5954bca8aca39ec3137d4d3b911a26ff0b0964a7ae98dL46-R46)
* Refactored usages of `resolve` in `DiscordAuthor` to pass both UUID and username as needed. [[1]](diffhunk://#diff-c8f0f6a025672007e163784f952426f81491de159714d14956eb274ccaf60562L74-R74) [[2]](diffhunk://#diff-c8f0f6a025672007e163784f952426f81491de159714d14956eb274ccaf60562L102-R102)

**Other:**

* Incremented the configuration version to 38 to reflect the new options.