### PR TITLE
[FIX] Refactor player rank checks to use player object to fix condition ranks.

### DIFF
--- a/Common/src/main/java/com/hypherionmc/sdlink/compat/rolesync/impl/FTBRankSync.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/compat/rolesync/impl/FTBRankSync.java
@@ -38,7 +38,7 @@ public final class FTBRankSync extends AbstractRoleSyncer {
                 Optional<RoleSyncCompat.Sync> sync = SDLinkCompatConfig.INSTANCE.ftbRanksCompat.syncs.stream().filter(s -> s.role.equalsIgnoreCase(role.getId())).findFirst();
 
                 sync.ifPresent(s -> {
-                    if (!FTBRanks.getInstance().hasRank(p.getGameProfile(), s.rank)) {
+                    if (!FTBRanks.getInstance().hasRank(p, s.rank)) {
                         ignoreEvent = true;
                         FTBRanks.getInstance().addRank(p.getGameProfile(), s.rank);
                         ignoreEvent = false;
@@ -47,12 +47,12 @@ public final class FTBRankSync extends AbstractRoleSyncer {
             }
 
             // Remove Ranks from Users
-            List<? extends CraterFTBRank> ranks = FTBRanks.getInstance().getPlayerRanks(p.getGameProfile());
+            List<? extends CraterFTBRank> ranks = FTBRanks.getInstance().getPlayerRanks(p);
             for (CraterFTBRank rank : ranks) {
                 Optional<RoleSyncCompat.Sync> sync = SDLinkCompatConfig.INSTANCE.ftbRanksCompat.syncs.stream().filter(s -> s.rank.equalsIgnoreCase(rank.name()) || s.rank.equalsIgnoreCase(rank.id())).findFirst();
 
                 sync.ifPresent(s -> {
-                    if (roles.stream().noneMatch(r -> r.getId().equalsIgnoreCase(s.role)) && FTBRanks.getInstance().hasRank(p.getGameProfile(), s.rank)) {
+                    if (roles.stream().noneMatch(r -> r.getId().equalsIgnoreCase(s.role)) && FTBRanks.getInstance().hasRank(p, s.rank)) {
                         ignoreEvent = true;
                         FTBRanks.getInstance().removeRank(p.getGameProfile(), s.rank);
                         ignoreEvent = false;
@@ -63,7 +63,7 @@ public final class FTBRankSync extends AbstractRoleSyncer {
 
         // Minecraft to Discord Sync
         if (SDLinkCompatConfig.INSTANCE.ftbRanksCompat.syncToDiscord) {
-            List<? extends CraterFTBRank> ranks = FTBRanks.getInstance().getPlayerRanks(p.getGameProfile());
+            List<? extends CraterFTBRank> ranks = FTBRanks.getInstance().getPlayerRanks(p);
 
             // Add Roles to Users
             for (CraterFTBRank rank : ranks) {
@@ -85,7 +85,7 @@ public final class FTBRankSync extends AbstractRoleSyncer {
             for (Role role : roles) {
                 Optional<RoleSyncCompat.Sync> sync = SDLinkCompatConfig.INSTANCE.ftbRanksCompat.syncs.stream().filter(s -> s.role.equalsIgnoreCase(role.getId())).findFirst();
 
-                if (sync.isPresent() && !FTBRanks.getInstance().hasRank(p.getGameProfile(), sync.get().rank)) {
+                if (sync.isPresent() && !FTBRanks.getInstance().hasRank(p, sync.get().rank)) {
                     Optional<Role> r = RoleManager.getFtbRanksRoles().stream().filter(rr -> rr.getId().equalsIgnoreCase(sync.get().role)).findFirst();
                     if (r.isEmpty())
                         return;


### PR DESCRIPTION
This PR adds support for querying conditional/active FTB Ranks for online players while preserving the existing behavior for profile-based lookups.

Previously, CraterGameProfile lookups used RankManager.getAddedRanks(...), which only returns explicitly assigned ranks. This made it impossible for integrations to detect ranks granted through FTB Ranks conditions.

Changes
Updated FTB Ranks role synchronization to use getPlayerRanks(CraterPlayer) instead of the profile-based lookup. CraterLib Pull required to enable this.
Updated active rank checks during synchronization to use hasRank(CraterPlayer, String).