### PR TITLE
Feat/sync command

### DIFF
--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/CommandManager.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/CommandManager.java
@@ -8,6 +8,7 @@ import com.hypherionmc.craterlib.core.event.CraterEventBus;
 import com.hypherionmc.sdlink.core.discord.commands.slash.general.HelpSlashCommand;
 import com.hypherionmc.sdlink.core.discord.commands.slash.general.PlayerListSlashCommand;
 import com.hypherionmc.sdlink.core.discord.commands.slash.general.ServerStatusSlashCommand;
+import com.hypherionmc.sdlink.core.discord.commands.slash.general.SyncCommand;
 import com.hypherionmc.sdlink.core.discord.commands.slash.hide.HiddenPlayersCommand;
 import com.hypherionmc.sdlink.core.discord.commands.slash.hide.HidePlayerCommand;
 import com.hypherionmc.sdlink.core.discord.commands.slash.hide.UnhidePlayerCommand;
@@ -46,6 +47,7 @@ public final class CommandManager {
         commands.add(new StaffUnverifyCommand());
         commands.add(new StaffVerifyAccountCommand());
         commands.add(new ViewVerifiedAccounts());
+        commands.add(new SyncCommand());
 
         // Enable the Server Status command
         commands.add(new ServerStatusSlashCommand());

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
@@ -3,6 +3,7 @@ package com.hypherionmc.sdlink.core.discord.commands.slash.general;
 import com.hypherionmc.sdlink.core.config.SDLinkConfig;
 import com.hypherionmc.sdlink.core.discord.commands.slash.SDLinkSlashCommand;
 import com.hypherionmc.sdlink.core.managers.DatabaseManager;
+import com.hypherionmc.sdlink.util.SDLinkUtils;
 import com.hypherionmc.sdlinkrw.SDLinkConstants;
 import com.hypherionmc.sdlinkrw.api.accounts.MinecraftAccount;
 import com.hypherionmc.sdlinkrw.modules.database.SDLinkAccount;
@@ -13,7 +14,7 @@ import net.dv8tion.jda.api.entities.Member;
 import java.util.List;
 
 /**
- * @Author SuperficialCake
+ * @author SuperficialCake
  * Staff command to resync Discord with Minecraft
  */
 public class SyncCommand extends SDLinkSlashCommand {
@@ -36,8 +37,7 @@ public class SyncCommand extends SDLinkSlashCommand {
         }
 
         try {
-
-            List<SDLinkAccount> accounts = DatabaseManager.INSTANCE.findAll(SDLinkAccount.class);
+            List<SDLinkAccount> accounts = DatabaseManager.INSTANCE.findAll(SDLinkAccount.class).stream().filter(account -> !SDLinkUtils.isNullOrEmpty(account.getDiscordID())).toList();
 
             if (accounts.isEmpty()) {
                 event.getHook().sendMessage(SDText.translate("command.verifiedaccounts.no_accounts").toString()).setEphemeral(true).queue();
@@ -45,11 +45,7 @@ public class SyncCommand extends SDLinkSlashCommand {
             }
 
             for (SDLinkAccount itm : accounts) {
-                Member discordMember = null;
-
-                if (itm.getDiscordID() != null && !itm.getDiscordID().isBlank()){
-                    discordMember = event.getGuild().getMemberById(itm.getDiscordID());
-                }
+                Member discordMember = event.getGuild().getMemberById(itm.getDiscordID());
 
                 if (discordMember.getNickname() == null || discordMember.getNickname() != itm.getInGameName()) {
                     MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
@@ -56,6 +56,8 @@ public class SyncCommand extends SDLinkSlashCommand {
                     minecraftAccount.verifyAccount(discordMember);
                 }
 
+                // TODO: Add logic for multiple discord servers
+
                 List<String> memberRoles = discordMember.getRoles().stream()
                         .map(Role::getId)
                         .toList();

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
@@ -10,8 +10,12 @@ import com.hypherionmc.sdlinkrw.modules.database.SDLinkAccount;
 import com.hypherionmc.sdlinkrw.modules.translations.SDText;
 import com.jagrosh.jdautilities.command.SlashCommandEvent;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * @author SuperficialCake
@@ -52,7 +56,11 @@ public class SyncCommand extends SDLinkSlashCommand {
                     minecraftAccount.verifyAccount(discordMember);
                 }
 
-                if (discordMember.getRoles().contains(SDLinkConfig.INSTANCE.accessControl.verifiedRole.toString())) {
+                List<String> memberRoles = discordMember.getRoles().stream()
+                        .map(Role::getId)
+                        .toList();
+
+                if (!memberRoles.containsAll(SDLinkConfig.INSTANCE.accessControl.verifiedRole)) {
                     MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
                     minecraftAccount.verifyAccount(discordMember);
                 }

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
@@ -30,7 +30,13 @@ public class SyncCommand extends SDLinkSlashCommand {
     protected void execute(SlashCommandEvent event){
         event.deferReply(SDLinkConfig.INSTANCE.botConfig.silentReplies).queue();
 
+        if (!SDLinkConfig.INSTANCE.accessControl.enabled) {
+            event.getHook().sendMessage(SDText.translate("command.sync.access_control_disabled").toString()).setEphemeral(SDLinkConfig.INSTANCE.botConfig.silentReplies).queue();
+            return;
+        }
+
         try {
+
             List<SDLinkAccount> accounts = DatabaseManager.INSTANCE.findAll(SDLinkAccount.class);
 
             if (accounts.isEmpty()) {
@@ -45,12 +51,12 @@ public class SyncCommand extends SDLinkSlashCommand {
                     discordMember = event.getGuild().getMemberById(itm.getDiscordID());
                 }
 
-                if (discordMember.getNickname() == null || discordMember.getNickname() != itm.getInGameName() && SDLinkConfig.INSTANCE.accessControl.enabled) {
+                if (discordMember.getNickname() == null || discordMember.getNickname() != itm.getInGameName()) {
                     MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
                     minecraftAccount.verifyAccount(discordMember);
                 }
 
-                if (discordMember.getRoles().contains(SDLinkConfig.INSTANCE.accessControl.verifiedRole.toString()) && SDLinkConfig.INSTANCE.accessControl.enabled) {
+                if (discordMember.getRoles().contains(SDLinkConfig.INSTANCE.accessControl.verifiedRole.toString())) {
                     MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
                     minecraftAccount.verifyAccount(discordMember);
                 }

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
@@ -1,0 +1,66 @@
+package com.hypherionmc.sdlink.core.discord.commands.slash.general;
+
+import com.hypherionmc.sdlink.core.config.SDLinkConfig;
+import com.hypherionmc.sdlink.core.discord.commands.slash.SDLinkSlashCommand;
+import com.hypherionmc.sdlink.core.managers.DatabaseManager;
+import com.hypherionmc.sdlinkrw.SDLinkConstants;
+import com.hypherionmc.sdlinkrw.api.accounts.MinecraftAccount;
+import com.hypherionmc.sdlinkrw.modules.database.SDLinkAccount;
+import com.hypherionmc.sdlinkrw.modules.translations.SDText;
+import com.jagrosh.jdautilities.command.SlashCommandEvent;
+import net.dv8tion.jda.api.entities.Member;
+
+import java.util.List;
+
+/**
+ * @Author SuperficialCake
+ * Staff command to resync Discord with Minecraft
+ */
+public class SyncCommand extends SDLinkSlashCommand {
+
+    public SyncCommand() {
+        super(true);
+
+        this.name = "sync";
+        this.help = SDText.translate("command.sync.help").toString();
+        this.guildOnly = true;
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event){
+        event.deferReply(SDLinkConfig.INSTANCE.botConfig.silentReplies).queue();
+
+        try {
+            List<SDLinkAccount> accounts = DatabaseManager.INSTANCE.findAll(SDLinkAccount.class);
+
+            if (accounts.isEmpty()) {
+                event.getHook().sendMessage(SDText.translate("command.verifiedaccounts.no_accounts").toString()).setEphemeral(true).queue();
+                return;
+            }
+
+            for (SDLinkAccount itm : accounts) {
+                Member discordMember = null;
+
+                if (itm.getDiscordID() != null && !itm.getDiscordID().isBlank()){
+                    discordMember = event.getGuild().getMemberById(itm.getDiscordID());
+                }
+
+                if (discordMember.getNickname() == null || discordMember.getNickname() != itm.getInGameName() && SDLinkConfig.INSTANCE.accessControl.enabled) {
+                    MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
+                    minecraftAccount.verifyAccount(discordMember);
+                }
+
+                if (discordMember.getRoles().contains(SDLinkConfig.INSTANCE.accessControl.verifiedRole.toString()) && SDLinkConfig.INSTANCE.accessControl.enabled) {
+                    MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
+                    minecraftAccount.verifyAccount(discordMember);
+                }
+            }
+
+            event.getHook().sendMessage(SDText.translate("command.sync.synced").toString()).setEphemeral(SDLinkConfig.INSTANCE.botConfig.silentReplies).queue();
+
+        } catch (Exception e){
+            event.getHook().sendMessage(SDText.translate("error.command_failed").toString()).setEphemeral(SDLinkConfig.INSTANCE.botConfig.silentReplies).queue();
+            SDLinkConstants.LOGGER.error("Failed to run sync command", e);
+        }
+    }
+}

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
@@ -35,6 +35,8 @@ public class SyncCommand extends SDLinkSlashCommand {
     protected void execute(SlashCommandEvent event){
         event.deferReply(SDLinkConfig.INSTANCE.botConfig.silentReplies).queue();
 
+        // TODO: Add logic for multiple discord servers
+
         if (!SDLinkConfig.INSTANCE.accessControl.enabled) {
             event.getHook().sendMessage(SDText.translate("command.sync.access_control_disabled").toString()).setEphemeral(SDLinkConfig.INSTANCE.botConfig.silentReplies).queue();
             return;
@@ -56,7 +58,7 @@ public class SyncCommand extends SDLinkSlashCommand {
                     minecraftAccount.verifyAccount(discordMember);
                 }
 
-                // TODO: Add logic for multiple discord servers
+
 
                 List<String> memberRoles = discordMember.getRoles().stream()
                         .map(Role::getId)

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
@@ -11,11 +11,7 @@ import com.hypherionmc.sdlinkrw.modules.translations.SDText;
 import com.jagrosh.jdautilities.command.SlashCommandEvent;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
-
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * @author SuperficialCake

--- a/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
+++ b/Common/src/main/java/com/hypherionmc/sdlink/core/discord/commands/slash/general/SyncCommand.java
@@ -47,22 +47,29 @@ public class SyncCommand extends SDLinkSlashCommand {
             }
 
             for (SDLinkAccount itm : accounts) {
-                Member discordMember = event.getGuild().getMemberById(itm.getDiscordID());
+                try {
 
-                if (discordMember.getNickname() == null || discordMember.getNickname() != itm.getInGameName()) {
-                    MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
-                    minecraftAccount.verifyAccount(discordMember);
-                }
+                    Member discordMember = event.getGuild().getMemberById(itm.getDiscordID());
 
+                    if (discordMember == null) {
+                        continue;
+                    }
 
+                    if (discordMember.getNickname() == null || !discordMember.getNickname().equals(itm.getInGameName())) {
+                        MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
+                        minecraftAccount.verifyAccount(discordMember);
+                    }
 
-                List<String> memberRoles = discordMember.getRoles().stream()
-                        .map(Role::getId)
-                        .toList();
+                    List<String> memberRoles = discordMember.getRoles().stream()
+                            .map(Role::getId)
+                            .toList();
 
-                if (!memberRoles.containsAll(SDLinkConfig.INSTANCE.accessControl.verifiedRole)) {
-                    MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
-                    minecraftAccount.verifyAccount(discordMember);
+                    if (!memberRoles.containsAll(SDLinkConfig.INSTANCE.accessControl.verifiedRole)) {
+                        MinecraftAccount minecraftAccount = MinecraftAccount.of(itm);
+                        minecraftAccount.verifyAccount(discordMember);
+                    }
+                } catch (Exception e) {
+                    SDLinkConstants.LOGGER.error("Failed to sync one or more accounts", e);
                 }
             }
 

--- a/Common/src/main/resources/assets/sdlink/lang/en_us.json
+++ b/Common/src/main/resources/assets/sdlink/lang/en_us.json
@@ -57,6 +57,9 @@
   "command.staffunverify.help": "Unverify another player's Minecraft account",
   "command.staffverify.help": "Allow staff members verify minecraft players, without verification",
 
+  "command.sync.help": "Force a resync of Discord and Minecraft",
+  "command.sync.synced": "Successfully resynced SDLink Storage with Minecraft",
+
   "command.unverify.help": "Unverify your previously verified Minecraft account",
   "command.unverify.failed": "Sorry, we could not un-verify your Minecraft account. Please try again",
 

--- a/Common/src/main/resources/assets/sdlink/lang/en_us.json
+++ b/Common/src/main/resources/assets/sdlink/lang/en_us.json
@@ -59,6 +59,7 @@
 
   "command.sync.help": "Force a resync of Discord and Minecraft",
   "command.sync.synced": "Successfully resynced SDLink Storage with Minecraft",
+  "command.sync.access_control_disabled": "Access Control is disabled. Nothing to sync",
 
   "command.unverify.help": "Unverify your previously verified Minecraft account",
   "command.unverify.failed": "Sorry, we could not un-verify your Minecraft account. Please try again",


### PR DESCRIPTION
[FEAT] Adds a `/sync` command to resync the sdlink storage file with Discord members' nickames and roles